### PR TITLE
msm8226-common: PowerHAL: Change min freq depending on screen state

### DIFF
--- a/power/power.c
+++ b/power/power.c
@@ -103,6 +103,8 @@ static void power_set_interactive(__attribute__((unused)) struct power_module *m
                         profiles[current_power_profile].go_hispeed_load);
         sysfs_write_str(INTERACTIVE_PATH "target_loads",
                         profiles[current_power_profile].target_loads);
+        sysfs_write_int(CPUFREQ_PATH "scaling_min_freq",
+                        profiles[current_power_profile].scaling_min_freq);
     } else {
         sysfs_write_int(INTERACTIVE_PATH "hispeed_freq",
                         profiles[current_power_profile].hispeed_freq_off);
@@ -110,6 +112,8 @@ static void power_set_interactive(__attribute__((unused)) struct power_module *m
                         profiles[current_power_profile].go_hispeed_load_off);
         sysfs_write_str(INTERACTIVE_PATH "target_loads",
                         profiles[current_power_profile].target_loads_off);
+        sysfs_write_int(CPUFREQ_PATH "scaling_min_freq",
+                        profiles[current_power_profile].scaling_min_freq_off);
     }
 }
 
@@ -143,6 +147,8 @@ static void set_power_profile(int profile)
                     profiles[profile].target_loads);
     sysfs_write_int(CPUFREQ_PATH "scaling_max_freq",
                     profiles[profile].scaling_max_freq);
+    sysfs_write_int(CPUFREQ_PATH "scaling_min_freq",
+                    profiles[profile].scaling_min_freq);
 
     current_power_profile = profile;
 }

--- a/power/power.h
+++ b/power/power.h
@@ -36,6 +36,8 @@ typedef struct governor_settings {
     char *target_loads;
     char *target_loads_off;
     int scaling_max_freq;
+    int scaling_min_freq;
+    int scaling_min_freq_off;
 } power_profile;
 
 static power_profile profiles[PROFILE_MAX] = {
@@ -52,6 +54,8 @@ static power_profile profiles[PROFILE_MAX] = {
         .target_loads = "95 1190400:99",
         .target_loads_off = "95 1190400:99",
         .scaling_max_freq = 787200,
+        .scaling_min_freq = 300000,
+        .scaling_min_freq_off = 300000,
     },
     [PROFILE_BALANCED] = {
         .boost = 0,
@@ -66,6 +70,8 @@ static power_profile profiles[PROFILE_MAX] = {
         .target_loads = "80 998400:90 1190400:99",
         .target_loads_off = "95 1190400:99",
         .scaling_max_freq = 1190400,
+        .scaling_min_freq = 787200,
+        .scaling_min_freq_off = 300000,
     },
     [PROFILE_HIGH_PERFORMANCE] = {
         .boost = 1,
@@ -82,6 +88,8 @@ static power_profile profiles[PROFILE_MAX] = {
         .target_loads = "80",
         .target_loads_off = "80",
         .scaling_max_freq = 1190400,
+        .scaling_min_freq = 787200,
+        .scaling_min_freq_off = 300000,
     },
     [PROFILE_BIAS_POWER_SAVE] = {
         .boost = 0,
@@ -96,5 +104,7 @@ static power_profile profiles[PROFILE_MAX] = {
         .target_loads = "95 1190400:99",
         .target_loads_off = "95 1190400:99",
         .scaling_max_freq = 1190400,
+        .scaling_min_freq = 787200,
+        .scaling_min_freq_off = 300000,
     },
 };

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -755,11 +755,6 @@ on property:sys.boot_completed=1
     write /sys/module/msm_pm/modes/cpu2/retention/idle_enabled 1
     write /sys/module/msm_pm/modes/cpu3/retention/idle_enabled 1
 
-    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq 300000
-    write /sys/devices/system/cpu/cpu1/cpufreq/scaling_min_freq 300000
-    write /sys/devices/system/cpu/cpu2/cpufreq/scaling_min_freq 300000
-    write /sys/devices/system/cpu/cpu3/cpufreq/scaling_min_freq 300000
-
     chown root system /sys/devices/system/cpu/cpu1/online
     chown root system /sys/devices/system/cpu/cpu2/online
     chown root system /sys/devices/system/cpu/cpu3/online


### PR DESCRIPTION
According to CAF [1], increasing the minimum frequency to 787200 Hz
allows to efficiently achieve good performance, so increase the min
frequency when the screen is on, except when the power save profile
is used.

[1] https://www.codeaurora.org/cgit/quic/la/device/qcom/common/commit/?id=2bb61fabcbaed2125d34c30035ad8b704bd0a62f

Change-Id: I67a707db8ae187da1eef124e1fac777a26018d75
