### PR TITLE
msm8226-common: camera: Enable HFR video recording

### DIFF
--- a/camera/CameraWrapper.cpp
+++ b/camera/CameraWrapper.cpp
@@ -58,6 +58,8 @@ static int camera_device_open(const hw_module_t *module, const char *name,
 static int camera_get_number_of_cameras(void);
 static int camera_get_camera_info(int camera_id, struct camera_info *info);
 
+static char videoHfr[4] = "off";
+
 static struct hw_module_methods_t camera_module_methods = {
     .open = camera_device_open
 };
@@ -154,7 +156,12 @@ static char *camera_fixup_getparams(int id, const char *settings)
         if (id == BACK_CAMERA) {
             params.set(CameraParameters::KEY_QC_SUPPORTED_ISO_MODES,
                     "auto,ISO_HJR,ISO100,ISO200,ISO400,ISO800,ISO1600");
+            params.set(CameraParameters::KEY_QC_SUPPORTED_HFR_SIZES, "1296x728");
+            params.set(CameraParameters::KEY_QC_SUPPORTED_VIDEO_HIGH_FRAME_RATE_MODES, "60,off");
         }
+    } else {
+        params.set(CameraParameters::KEY_QC_SUPPORTED_HFR_SIZES, "1296x728,1296x728,720x480");
+        params.set(CameraParameters::KEY_QC_SUPPORTED_VIDEO_HIGH_FRAME_RATE_MODES, "60,90,120,off");
     }
 
     if (!(get_product_device() == FALCON || get_product_device() == PEREGRINE) ||
@@ -165,6 +172,9 @@ static char *camera_fixup_getparams(int id, const char *settings)
                 "candlelight,beach,snow,sunset,steadyphoto,fireworks,sports,party,"
                 "auto_hdr,hdr,asd,backlight,flowers,AR");
     }
+
+    /* HFR video recording workaround */
+    params.set(CameraParameters::KEY_QC_VIDEO_HIGH_FRAME_RATE, videoHfr);
 
 #if !LOG_NDEBUG
     ALOGV("%s: fixed parameters:", __FUNCTION__);
@@ -186,6 +196,14 @@ static char *camera_fixup_setparams(int id, const char *settings)
     ALOGV("%s: original parameters:", __FUNCTION__);
     params.dump();
 #endif
+
+    /*
+     * The video-hfr parameter gets removed from the parameters list by the
+     * vendor call, unless the Motorola camera app is used. Save the value
+     * so that we can later return it.
+     */
+    const char *hfr = params.get(CameraParameters::KEY_QC_VIDEO_HIGH_FRAME_RATE);
+    snprintf(videoHfr, sizeof(videoHfr), "%s", hfr ? hfr : "off");
 
     if (get_product_device() == FALCON || get_product_device() == PEREGRINE) {
         if (id == BACK_CAMERA) {


### PR DESCRIPTION
The video-hfr parameter gets removed from the list by the vendor
HAL, unless the Motorola camera app is used. Save the value when
the parameter is set and return it when the parameter list is
requested to get around this limitation.

Change-Id: I460d57db7deb518c08c9b470eca5c2f3c42184fa
